### PR TITLE
Fix for false ryanpeikou

### DIFF
--- a/src/mahjong/analyze/yaku/ryanpeikou.coffee
+++ b/src/mahjong/analyze/yaku/ryanpeikou.coffee
@@ -10,10 +10,10 @@ module.exports =
 
         identical = 0
         for a in sets
-            count = 0
             for b in sets
                 continue if a.id == b.id
                 identical++ if a.value == b.value
-
+        
+        return if identical == 6
         return if identical < 4
         return 3


### PR DESCRIPTION
The super simple fix is to check that we don't have 6 matches.  This is to specifically fix when you have 3 pon in hand.

Maybe an even simpler fix would be to `return if indentical == 4 then 3 else 0`?