### PR TITLE
fix(ui): Improve Mobile experience

### DIFF
--- a/src/pages/index.tag.html
+++ b/src/pages/index.tag.html
@@ -25,7 +25,9 @@
 
         @VERSION = VERSION
 
-        @onNext = (e) => @tags.game.actions.reload()
+        @onNext = (e) ->
+            @tags.game.actions.reload()
+            window.scrollTo(0, 0)
 
     </script>
 </app>

--- a/src/styles/base.sass
+++ b/src/styles/base.sass
@@ -30,3 +30,7 @@ body
 .mj-dora-list
   @include media('<tablet')
     grid-column: 1 / -1
+
+.mj-hand
+  justify-content: space-between
+  flex-wrap: wrap

--- a/src/styles/base.sass
+++ b/src/styles/base.sass
@@ -20,3 +20,13 @@ body
 
 .u-bold
   font-weight: 600 !important
+
+.mj-header
+  @include media('<tablet')
+    display: grid !important
+    grid-template-columns: 1fr 1fr
+    gap: 1rem
+
+.mj-dora-list
+  @include media('<tablet')
+    grid-column: 1 / -1

--- a/src/styles/base.sass
+++ b/src/styles/base.sass
@@ -34,3 +34,8 @@ body
 .mj-hand
   justify-content: space-between
   flex-wrap: wrap
+
+[aria-label][role~=tooltip]::after
+  @include media('<tablet')
+    white-space: normal
+    text-align: center

--- a/src/tags/game/index.tag.html
+++ b/src/tags/game/index.tag.html
@@ -5,13 +5,13 @@
             <wind wind={ state.prevalentWind } title="round"/>
             <div class="u-mla mj-dora-list">
                 <wall tiles={ wall1 } />
-            </div>
-        </div>
-        <div class="u-flex u-flex--align-end u-mb4" style="height: 100px">
-            <div if={ state.hand.options.riichi } class="c-riichi" aria-label="The Player has declared Riichi" role="tooltip" data-microtip-position="top">•</div>
             <div if={ state.hand.options.riichi } class="u-mla">
                 <wall tiles={ wall2 } no-title={ true }/>
             </div>
+            </div>
+        </div>
+        <div class="u-mt4 u-mb4">
+            <div if={ state.hand.options.riichi } class="c-riichi" aria-label="The Player has declared Riichi" role="tooltip" data-microtip-position="top">•</div>
         </div>
 
         <hand hand={ state.hand } number={ state.number }/>

--- a/src/tags/game/index.tag.html
+++ b/src/tags/game/index.tag.html
@@ -1,9 +1,9 @@
 <game>
     <div if={ state.inited }>
-        <div class="u-flex u-mt4">
+        <div class="u-flex u-mt4 mj-header">
             <wind wind={ state.seatWind } seat={ true } title="seat"/>
             <wind wind={ state.prevalentWind } title="round"/>
-            <div class="u-mla">
+            <div class="u-mla mj-dora-list">
                 <wall tiles={ wall1 } />
             </div>
         </div>

--- a/src/tags/hand/index.tag.html
+++ b/src/tags/hand/index.tag.html
@@ -1,14 +1,19 @@
 <hand>
-    <div class="u-flex u-mb2">
-        <span class="u-bold"> HAND #{ opts.number } </span>
-        <span class="u-mla u-center" style="width: 70px">
-            { opts.hand.tsumo && 'TSUMO' || 'RON' }
-        </span>
-    </div>
-    <div class="u-flex u-flex--center">
-        <tile each={ tile in opts.hand.tiles() } if={ tile.id != opts.hand.wait.id } tile={ tile } />
-        <div class="u-mla"></div>
-        <tile tile={ opts.hand.wait } open={ !opts.hand.tsumo }/>
+    <div class="u-flex mj-hand">
+        <div>
+            <div class="u-flex u-mb2">
+                <span class="u-bold"> HAND #{ opts.number } </span>
+            </div>
+            <div class="u-flex u-flex--wrap">
+                <tile each={ tile in opts.hand.tiles() } if={ tile.id != opts.hand.wait.id } tile={ tile } />
+            </div>
+        </div>
+        <div>
+            <span class="u-mla u-center" style="width: 70px">
+                { opts.hand.tsumo && 'TSUMO' || 'RON' }
+            </span>
+            <tile tile={ opts.hand.wait } open={ !opts.hand.tsumo }/>
+        </div>
     </div>
 
     <script type="text/coffeescript">


### PR DESCRIPTION
## Description

This PR fixes #1 and improves the mobile experience by ensuring the hand wraps around and that the viewport need not to scroll horizontally in mobile. It also fixes the situation where you click 'Next hand' but because you've scrolled to the bottom, you need to manually scroll to the top again, by auto scrolling to the top on next hand.

I've been using these fixed changes on [my own deployed version](https://vince.id.au/mahjong.horneds.com/) for a while now, but recently checked that the mobile experience was still cooked on the main website so I figured I would open a PR. Not super fussed if this gets merged or not, but opening a PR in case you find it helpful.

## Screenshots

### Before

Note the overflow and the scrollbar at the bottom.

<img width="450" height="1130" alt="Screenshot 2026-06-26 at 10 43 51 pm" src="https://github.com/user-attachments/assets/fe27105e-547c-4494-90db-b4bb0dfae1ee" />



### After

No overflow. No scrollbar.

<img width="450" height="1130" alt="Screenshot 2026-06-26 at 10 44 03 pm" src="https://github.com/user-attachments/assets/43bbb3b1-2bca-4e0c-ac09-027fe54df3d9" />

